### PR TITLE
Mark tests as proper Test Assemblies and rely on testables (hide by default)

### DIFF
--- a/src/ControllersTree/Substitute/Tests/Playtika.Controllers.Substitute.Tests.asmdef
+++ b/src/ControllersTree/Substitute/Tests/Playtika.Controllers.Substitute.Tests.asmdef
@@ -5,7 +5,9 @@
         "Playtika.Controllers.Substitute",
         "UniTask"
     ],
-    "optionalUnityReferences": [],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/src/ControllersTree/Tests/Controllers/ControllersWithResult/ActionModelTestControllerWithResult.cs
+++ b/src/ControllersTree/Tests/Controllers/ControllersWithResult/ActionModelTestControllerWithResult.cs
@@ -29,8 +29,7 @@ namespace UnitTests.Controllers
 
         protected override async UniTask OnFlowAsync(CancellationToken cancellationToken)
         {
-            base.OnFlowAsync(cancellationToken);
-
+            await base.OnFlowAsync(cancellationToken);
             await UniTask.Delay(10, cancellationToken: cancellationToken);
             TestControllersActionModel.TriggerFlow();
             await UniTask.Delay(10, cancellationToken: cancellationToken);

--- a/src/ControllersTree/Tests/Controllers/ControllersWithResult/Childs/ActionModelTestChildControllerWithResult.cs
+++ b/src/ControllersTree/Tests/Controllers/ControllersWithResult/Childs/ActionModelTestChildControllerWithResult.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Controllers
 
         protected override async UniTask OnFlowAsync(CancellationToken cancellationToken)
         {
-            base.OnFlowAsync(cancellationToken);
+            await base.OnFlowAsync(cancellationToken);
             await Task.Delay(50, cancellationToken).ConfigureAwait(false);
 
             TestChildControllersActionModel.TriggerChildFlow(TestControllerGuid);

--- a/src/ControllersTree/Tests/Playtika.Controllers.Tests.asmdef
+++ b/src/ControllersTree/Tests/Playtika.Controllers.Tests.asmdef
@@ -5,7 +5,9 @@
     "Playtika.Controllers.Substitute",
     "UniTask"
   ],
-  "optionalUnityReferences": [],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
   "includePlatforms": [
     "Editor"
   ],


### PR DESCRIPTION
Marked package test assemblies with "optionalUnityReferences": ["TestAssemblies"].

Result: tests from the package no longer appear in consumer projects by default; they’re enabled opt-in via project Packages/manifest.json → "testables".

```json
{
  "dependencies": {
    "com.playtika.controllers-tree": "https://github.com/PlaytikaOSS/controllers-tree.git?path=src/ControllersTree#v1.1.0"
  },
  "testables": [
    "com.playtika.controllers-tree"
  ]
}
```

Reference: Unity 6.2 Manual — Add tests to a package (layout, testables, and marking test assemblies). 
[docs.unity3d.com](https://docs.unity3d.com/6000.2/Documentation/Manual/cus-tests.html)
