### PR TITLE
Safer controller dispose: preserve state and aggregate exceptions

### DIFF
--- a/src/ControllersTree/Core/Controllers/ControllerBase.cs
+++ b/src/ControllersTree/Core/Controllers/ControllerBase.cs
@@ -148,10 +148,16 @@ namespace Playtika.Controllers
                 case ControllerState.Running:
                 case ControllerState.Stopped:
                 {
-                    _lifetimeTokenSource?.Cancel();
-                    _compositeDisposables.Dispose();
-                    ListPool<IController>.Release(_childControllers);
-                    _state = ControllerState.Disposed;
+                    try
+                    {
+                        _lifetimeTokenSource?.Cancel();
+                        _compositeDisposables.Dispose();
+                    }
+                    finally
+                    {
+                        ListPool<IController>.Release(_childControllers);
+                        _state = ControllerState.Disposed;
+                    }
                     break;
                 }
 

--- a/src/ControllersTree/Core/Utils/ControllerCompositeDisposable.cs
+++ b/src/ControllersTree/Core/Utils/ControllerCompositeDisposable.cs
@@ -71,8 +71,13 @@ namespace Playtika.Controllers
             }
         }
 
-        private static void DisposeMany(IEnumerable<IDisposable> disposables)
+        private static void DisposeMany(IReadOnlyCollection<IDisposable> disposables)
         {
+            if (disposables == null || disposables.Count == 0)
+            {
+                return;
+            }
+
             using var pooledObject = ListPool<Exception>.Get(out var exceptionList);
             foreach (var disposable in disposables)
             {
@@ -86,11 +91,9 @@ namespace Playtika.Controllers
                 }
             }
 
-            switch (exceptionList.Count)
+            if (exceptionList.Count > 0)
             {
-                case 0: return;
-                case 1: throw exceptionList[0];
-                default: throw new AggregateException(exceptionList.ToList());
+                throw new AggregateException(exceptionList.ToList());
             }
         }
     }

--- a/src/ControllersTree/Tests/ControllerCompositeDisposableTests.cs
+++ b/src/ControllersTree/Tests/ControllerCompositeDisposableTests.cs
@@ -160,7 +160,7 @@ namespace UnitTests.Controllers
         }
 
         [Test]
-        public void ControllerCompositeDisposable_OneDisposableThrows_ThrowsSingleExceptionAndDisposesOthers()
+        public void ControllerCompositeDisposable_OneDisposableThrows_WrapsInAggregateAndDisposesOthers()
         {
             // Arrange
             var composite = new ControllerCompositeDisposable();
@@ -171,12 +171,14 @@ namespace UnitTests.Controllers
             composite.Add(normalDisposable);
 
             // Act
-            var exception = Assert.Throws<TestControllersException>(
+            var aggregate = Assert.Throws<AggregateException>(
                 () => composite.Dispose(),
-                "Expected TestControllersException from throwing disposable");
+                "Expected AggregateException wrapping the throwing disposable");
 
             // Assert
-            Assert.IsNotNull(exception, "Exception should not be null");
+            Assert.IsNotNull(aggregate, "AggregateException should not be null");
+            Assert.AreEqual(1, aggregate.InnerExceptions.Count, "AggregateException should wrap the single throwing disposable");
+            Assert.IsInstanceOf<TestControllersException>(aggregate.InnerExceptions[0]);
             Assert.AreEqual(1, throwingDisposable.DisposeCallCount, "Throwing disposable should be disposed exactly once");
             Assert.AreEqual(1, normalDisposable.DisposeCallCount, "Normal disposable should still be disposed exactly once");
         }

--- a/src/ControllersTree/Tests/ControllersWithResultBaseTests.cs
+++ b/src/ControllersTree/Tests/ControllersWithResultBaseTests.cs
@@ -215,7 +215,7 @@ namespace UnitTests.Controllers
                         .LaunchAsync<ActionModelTestControllerWithResult_CompleteOnStart, TestControllerArgs, TestEmptyControllerResult>(
                             args, _controllerFactory, CancellationToken);
             }
-            catch (TestControllersException)
+            catch (AggregateException)
             {
                 exceptionThrown = true;
             }
@@ -224,7 +224,7 @@ namespace UnitTests.Controllers
             Assert.True(startTriggered, "OnStart is not triggered");
             Assert.False(flowTriggered, "OnFlowAsync has been triggered");
             Assert.True(stopTriggered, "OnStop is not triggered");
-            Assert.IsTrue(exceptionThrown, "TestControllersException expected");
+            Assert.IsTrue(exceptionThrown, "AggregateException expected");
         }
 
         [Test]


### PR DESCRIPTION
A controller could stay in a non-Disposed state when a disposable threw during dispose, leaving the pooled child list unreleased. A single dispose exception was also thrown unwrapped, so callers had to handle different exception shapes.

Dispose now always completes the cleanup and always surfaces dispose exceptions as one AggregateException. The controller ends in Disposed, and callers handle a single exception type.