### PR TITLE
Fix CS0618 obsolete warnings in Controllers Hierarchy editor

### DIFF
--- a/src/ControllersTree/Editor/ControllersHierarchy/ControllerTreeView.cs
+++ b/src/ControllersTree/Editor/ControllersHierarchy/ControllerTreeView.cs
@@ -6,6 +6,12 @@ using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_0_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
+
 namespace Playtika.Controllers.Editor
 {
     public class ControllerTreeView : TreeView

--- a/src/ControllersTree/Editor/ControllersHierarchy/ControllersHierarchy.cs
+++ b/src/ControllersTree/Editor/ControllersHierarchy/ControllersHierarchy.cs
@@ -5,8 +5,13 @@ using System.Reflection;
 using System.Threading;
 using Playtika.Controllers;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+
+#if UNITY_6000_0_OR_NEWER
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace Playtika.Controllers.Editor
 {
@@ -24,20 +29,22 @@ namespace Playtika.Controllers.Editor
         public static void DisableUnityControllerProfilerDefine()
         {
             var buildTarget = EditorUserBuildSettings.selectedBuildTargetGroup;
-            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTarget);
+            var namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(buildTarget);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget);
             var definesList = defines.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             definesList.Remove(UnityControllerProfilerDefine);
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTarget, definesList.ToArray());
+            PlayerSettings.SetScriptingDefineSymbols(namedBuildTarget, definesList.ToArray());
         }
 #else
         [MenuItem("Tools/Controllers/Enable CONTROLLERS_PROFILER define", priority = 103)]
         public static void EnableUnityControllerProfilerDefine()
         {
             var buildTarget = EditorUserBuildSettings.selectedBuildTargetGroup;
-            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTarget);
+            var namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(buildTarget);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget);
             var definesList = defines.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             definesList.Add(UnityControllerProfilerDefine);
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTarget, definesList.ToArray());
+            PlayerSettings.SetScriptingDefineSymbols(namedBuildTarget, definesList.ToArray());
         }
 #endif
 

--- a/src/ControllersTree/Editor/ControllersHierarchy/ControllersTreeViewItem.cs
+++ b/src/ControllersTree/Editor/ControllersHierarchy/ControllersTreeViewItem.cs
@@ -4,6 +4,10 @@ using System.Reflection;
 using Playtika.Controllers;
 using UnityEditor.IMGUI.Controls;
 
+#if UNITY_6000_0_OR_NEWER
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+#endif
+
 namespace Playtika.Controllers.Editor
 {
     internal class ControllersTreeViewItem : TreeViewItem


### PR DESCRIPTION
Editor compiled with 12 `CS0618` warnings on cold import.

- `PlayerSettings.Get/SetScriptingDefineSymbolsForGroup` → `Get/SetScriptingDefineSymbols(NamedBuildTarget)` (deprecated since Unity 2021).
- Non-generic `TreeView`/`TreeViewItem`/`TreeViewState` → generic `<int>` via `using` aliases under `#if UNITY_6000_0_OR_NEWER`. Pre-Unity-6 (incl. minimum `unity: 2021.3`) keeps the non-generic API.

Result: 0 warnings, 60/60 EditMode tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Unity versions so the Controllers hierarchy editor continues to compile and work correctly.
  * Updated the menu actions for enabling and disabling the profiler define to use the latest supported Unity settings APIs.
  * Added version-aware handling for tree view types to avoid type mismatches on Unity 6000+.

* **Refactor**
  * Adjusted editor-side type bindings to support both older and newer Unity releases without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->